### PR TITLE
Fixed stylelint configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true
+    "source.fixAll.eslint": "always",
+    "source.fixAll.stylelint": "always"
   },
   "css.validate": false,
   "stylelint.validate": ["css", "scss"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -2143,38 +2143,6 @@
         "postcss-selector-parser": "^6.0.13"
       }
     },
-    "node_modules/@detra-lab/stylelint-config": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@detra-lab/stylelint-config/-/stylelint-config-0.1.0.tgz",
-      "integrity": "sha512-A5ZdmH7krYTm+W3dkqZYDFEMcGnK8d+y962f8zgnwJbrpvrBHV8GXBrtOMFFnLTSkrF+vO4HOaGyaJbrdiuUcA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-syntax": "0.36.2",
-        "stylelint-declaration-block-no-ignored-properties": "2.7.0",
-        "stylelint-order": "6.0.3"
-      },
-      "engines": {
-        "node": "16.x || 18.x",
-        "npm": "8.x || 9.x"
-      },
-      "peerDependencies": {
-        "postcss-scss": "^4.0.0",
-        "postcss-styled-syntax": "^0.4.0",
-        "stylelint": "^15.6.0",
-        "stylelint-scss": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "postcss-scss": {
-          "optional": true
-        },
-        "postcss-styled-syntax": {
-          "optional": true
-        },
-        "stylelint-scss": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.40.1",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.40.1.tgz",
@@ -17522,8 +17490,7 @@
       "resolved": "https://registry.npmjs.org/postcss-styled-syntax/-/postcss-styled-syntax-0.4.0.tgz",
       "integrity": "sha512-LvG++K8LtIyX1Q1mNuZVQYmBo+SCwn90cEkMigo4/I0QwXrEiYt8nPeJ5rrI5Uuh+5w7hRfPyJKlvQdhVZBhUg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "^5.47.0",
         "estree-walker": "^2.0.2"
@@ -17537,8 +17504,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
       "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -17552,8 +17518,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
       "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
-      "optional": true,
-      "peer": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0",
@@ -17581,8 +17546,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
       "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -17595,30 +17559,12 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/postcss-styled-syntax/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/postcss-styled-syntax/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -17626,19 +17572,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/postcss-styled-syntax/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/postcss-syntax": {
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "postcss": ">=5.0.0"
       }
@@ -20309,6 +20248,7 @@
       "resolved": "https://registry.npmjs.org/stylelint-declaration-block-no-ignored-properties/-/stylelint-declaration-block-no-ignored-properties-2.7.0.tgz",
       "integrity": "sha512-44SpI9+9Oc1ICuwwRfwS/3npQ2jPobDSTnwWdNgZGryGqQCp17CgEIWjCv1BgUOSzND3RqywNCNLKvO1AOxbfg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -21928,14 +21868,16 @@
       "license": "MIT",
       "devDependencies": {
         "@contactlab/stylelint-config": "1.0.0",
-        "@detra-lab/stylelint-config": "0.1.0",
         "eslint": "8.47.0",
         "eslint-config-contactlab": "11.2.0",
         "eslint-config-prettier": "9.0.0",
         "eslint-plugin-react": "7.33.2",
         "postcss-scss": "4.0.7",
+        "postcss-styled-syntax": "0.4.0",
+        "postcss-syntax": "0.36.2",
         "serve": "14.2.0",
         "stylelint": "15.10.2",
+        "stylelint-declaration-block-no-ignored-properties": "2.7.0",
         "stylelint-scss": "5.1.0",
         "typescript": "5.1.6"
       }
@@ -22279,7 +22221,6 @@
       "license": "MIT",
       "devDependencies": {
         "@contactlab/stylelint-config": "1.0.0",
-        "@detra-lab/stylelint-config": "0.1.0",
         "@parcel/config-default": "2.9.3",
         "@parcel/transformer-inline-string": "2.9.3",
         "@parcel/transformer-pug": "2.9.3",
@@ -22291,6 +22232,8 @@
         "eslint-plugin-react": "7.33.2",
         "parcel": "2.9.3",
         "postcss-scss": "4.0.7",
+        "postcss-styled-syntax": "0.4.0",
+        "postcss-syntax": "0.36.2",
         "stylelint": "15.10.3",
         "stylelint-scss": "5.1.0",
         "typescript": "5.1.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21864,7 +21864,7 @@
     },
     "packages/design-tokens": {
       "name": "@contactlab/ds-tokens",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "devDependencies": {
         "@contactlab/stylelint-config": "1.0.0",
@@ -22217,7 +22217,7 @@
     },
     "packages/service-pages": {
       "name": "@contactlab/service-pages",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "devDependencies": {
         "@contactlab/stylelint-config": "1.0.0",

--- a/packages/design-tokens/.stylelintrc.json
+++ b/packages/design-tokens/.stylelintrc.json
@@ -1,11 +1,18 @@
 {
-  "extends": [
-    "@contactlab/stylelint-config",
-    "@detra-lab/stylelint-config/sass"
+  "extends": ["@contactlab/stylelint-config"],
+  "customSyntax": "postcss-scss",
+  "plugins": [
+    "stylelint-scss",
+    "stylelint-declaration-block-no-ignored-properties"
   ],
   "rules": {
+    "color-function-notation": "legacy",
+    "font-weight-notation": ["numeric", {"ignore": ["relative"]}],
+    "function-no-unknown": null,
     "no-duplicate-selectors": null,
+    "plugin/declaration-block-no-ignored-properties": true,
     "property-no-unknown": null,
+    "scss/function-no-unknown": [true, {"ignoreFunctions": ["colors"]}],
     "scss/operator-no-unspaced": null
   }
 }

--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.1
+
+- Fixed stylelint configuration
+
 ## 3.4.0
 
 - Replace Marketing Cloud with MailUp CDP

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contactlab/ds-tokens",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Named entities that store visual-design info, in order to maintain a scalable, consistent system for user interface development.",
   "author": "Contactlab",
   "homepage": "https://github.com/contactlab/milky-way#readme",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -29,14 +29,16 @@
   },
   "devDependencies": {
     "@contactlab/stylelint-config": "1.0.0",
-    "@detra-lab/stylelint-config": "0.1.0",
     "eslint": "8.47.0",
     "eslint-config-contactlab": "11.2.0",
     "eslint-config-prettier": "9.0.0",
     "eslint-plugin-react": "7.33.2",
     "postcss-scss": "4.0.7",
+    "postcss-styled-syntax": "0.4.0",
+    "postcss-syntax": "0.36.2",
     "serve": "14.2.0",
     "stylelint": "15.10.2",
+    "stylelint-declaration-block-no-ignored-properties": "2.7.0",
     "stylelint-scss": "5.1.0",
     "typescript": "5.1.6"
   }

--- a/packages/service-pages/.stylelintrc.json
+++ b/packages/service-pages/.stylelintrc.json
@@ -1,6 +1,8 @@
 {
-  "extends": [
-    "@contactlab/stylelint-config",
-    "@detra-lab/stylelint-config/sass"
+  "extends": ["@contactlab/stylelint-config"],
+  "customSyntax": "postcss-scss",
+  "plugins": [
+    "stylelint-scss",
+    "stylelint-declaration-block-no-ignored-properties"
   ]
 }

--- a/packages/service-pages/CHANGELOG.md
+++ b/packages/service-pages/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.1
+
+- Fixed stylelint configuration
+
 ## 3.2.0
 
 - Replace Marketing Cloud with MailUp CDP

--- a/packages/service-pages/package.json
+++ b/packages/service-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contactlab/service-pages",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "The MailUp CDP service pages.",
   "author": "Contactlab",
   "homepage": "https://github.com/contactlab/milky-way#readme",

--- a/packages/service-pages/package.json
+++ b/packages/service-pages/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@contactlab/stylelint-config": "1.0.0",
-    "@detra-lab/stylelint-config": "0.1.0",
     "@parcel/config-default": "2.9.3",
     "@parcel/transformer-inline-string": "2.9.3",
     "@parcel/transformer-pug": "2.9.3",
@@ -38,6 +37,8 @@
     "eslint-plugin-react": "7.33.2",
     "parcel": "2.9.3",
     "postcss-scss": "4.0.7",
+    "postcss-styled-syntax": "0.4.0",
+    "postcss-syntax": "0.36.2",
     "stylelint": "15.10.3",
     "stylelint-scss": "5.1.0",
     "typescript": "5.1.6"


### PR DESCRIPTION
This PR fixes stylelint configuration problems due to the dependency @detra-lab/stylelint-config no more available on npm registry.

Stylelint configurations have been added to solve linting problems.

Those configurations are totally new as unfortunately the previous package isn't available anymore.
